### PR TITLE
[BE] chore: GroupInvitation 필드명 변경 및 초대 수락 API 수정 (#50)

### DIFF
--- a/backend/photoMap/src/main/java/com/codeZero/photoMap/controller/group/GroupController.java
+++ b/backend/photoMap/src/main/java/com/codeZero/photoMap/controller/group/GroupController.java
@@ -130,10 +130,10 @@ public class GroupController {
         //현재 사용자가 그룹의 소유자인지 확인
         groupService.verifyGroupOwner(groupId, memberId);
 
-        String token = groupService.createInvitation(request.getEmail(), groupId, memberId);
+        String groupToken = groupService.createInvitation(request.getEmail(), groupId, memberId);
         GroupInvitationResponse response = GroupInvitationResponse.builder()
                 .message("초대장이 성공적으로 발송되었습니다.")
-                .token(token)
+                .groupToken(groupToken)
                 .build();
 
         return ApiResponse.of(HttpStatus.CREATED, response);

--- a/backend/photoMap/src/main/java/com/codeZero/photoMap/controller/group/GroupInvitationController.java
+++ b/backend/photoMap/src/main/java/com/codeZero/photoMap/controller/group/GroupInvitationController.java
@@ -1,16 +1,17 @@
 package com.codeZero.photoMap.controller.group;
 
+import com.codeZero.photoMap.common.ApiResponse;
+import com.codeZero.photoMap.dto.group.request.GroupTokenRequest;
+import com.codeZero.photoMap.dto.group.response.GroupResponse;
 import com.codeZero.photoMap.security.CustomUserDetails;
 import com.codeZero.photoMap.service.group.GroupInvitationService;
+import com.codeZero.photoMap.service.group.GroupService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
 import java.net.URLEncoder;
@@ -21,34 +22,37 @@ import java.nio.charset.StandardCharsets;
 public class GroupInvitationController {
 
     private final GroupInvitationService groupInvitationService;
+    private final GroupService groupService;
 
-    public GroupInvitationController(GroupInvitationService groupInvitationService) {
+
+    public GroupInvitationController(GroupInvitationService groupInvitationService, GroupService groupService) {
         this.groupInvitationService = groupInvitationService;
+        this.groupService = groupService;
     }
 
     /**
      * 초대 수락 API
-     * @param token 초대 토큰
+     * @param request   그룹 초대 토큰 수락 요청 DTO
      * @param userDetails  로그인한 사용자의 CustomUserDetails 객체(토큰에서 추출된 로그인한 사용자 정보)
-     * @return ResponseEntity<String> 초대 수락 응답 메시지
+     * @return  ApiResponse 초대가 수락된 그룹의 정보 응답 DTO
      */
-    @GetMapping("/accept")
-    public ResponseEntity<String> acceptInvitation(
-            @RequestParam String token,
+    @PostMapping("/accept")
+    public ApiResponse<GroupResponse> acceptInvitation(
+            @RequestBody  GroupTokenRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
 
         //로그인되지 않은 상태에서 요청이 오면 401 응답 반환
         if (userDetails == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인이 필요합니다.");
+            return ApiResponse.of(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.", null);
         }
 
         //로그인된 사용자라면 초대 수락 처리
         Long memberId = userDetails.getId();
-        groupInvitationService.acceptInvitation(token, memberId);
+        Long groupId = groupInvitationService.acceptInvitation(request.getGroupToken(), memberId);
 
-        return ResponseEntity.ok("초대가 성공적으로 수락되었습니다.");
-
+        GroupResponse response = groupService.getGroup(groupId);
+        return ApiResponse.ok(response);
     }
 
 }

--- a/backend/photoMap/src/main/java/com/codeZero/photoMap/domain/group/GroupInvitation.java
+++ b/backend/photoMap/src/main/java/com/codeZero/photoMap/domain/group/GroupInvitation.java
@@ -18,7 +18,7 @@ public class GroupInvitation extends BaseEntity {
     private Long id;
 
     @Column(nullable = false)
-    private String token;   //고유 초대 토큰
+    private String groupToken;   //고유 초대 토큰
     @Column(nullable = false)
     private String email;   //초대받는 이메일
     @Column(nullable = false)
@@ -29,9 +29,9 @@ public class GroupInvitation extends BaseEntity {
     private boolean isUsed = false;   //토큰 사용 여부
 
     @Builder
-    private GroupInvitation(Long id, String token, String email, Long groupId, LocalDateTime expiryDate, boolean isUsed) {
+    private GroupInvitation(Long id, String groupToken, String email, Long groupId, LocalDateTime expiryDate, boolean isUsed) {
         this.id = id;
-        this.token = token;
+        this.groupToken = groupToken;
         this.email = email;
         this.groupId = groupId;
         this.expiryDate = expiryDate;

--- a/backend/photoMap/src/main/java/com/codeZero/photoMap/domain/group/GroupInvitationRepository.java
+++ b/backend/photoMap/src/main/java/com/codeZero/photoMap/domain/group/GroupInvitationRepository.java
@@ -10,7 +10,7 @@ public interface GroupInvitationRepository extends JpaRepository<GroupInvitation
     boolean existsByEmailAndGroupIdAndIsUsedTrue(String email, Long groupId);
 
     //주어진 토큰과 소프트 삭제되지 않은 상태의 초대를 조회
-    Optional<GroupInvitation> findByTokenAndIsDeletedFalse(String token);
+    Optional<GroupInvitation> findByGroupTokenAndIsDeletedFalse(String groupToken);
 
     //주어진 ID와 소프트 삭제되지 않은 상태의 초대를 조회
     Optional<GroupInvitation> findByIdAndIsDeletedFalse(Long id);

--- a/backend/photoMap/src/main/java/com/codeZero/photoMap/dto/group/request/GroupTokenRequest.java
+++ b/backend/photoMap/src/main/java/com/codeZero/photoMap/dto/group/request/GroupTokenRequest.java
@@ -1,0 +1,14 @@
+package com.codeZero.photoMap.dto.group.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class GroupTokenRequest {
+
+    @NotBlank(message = "초대 토큰은 필수입니다.")
+    private String groupToken;
+
+}

--- a/backend/photoMap/src/main/java/com/codeZero/photoMap/dto/group/response/GroupInvitationResponse.java
+++ b/backend/photoMap/src/main/java/com/codeZero/photoMap/dto/group/response/GroupInvitationResponse.java
@@ -7,12 +7,12 @@ import lombok.Getter;
 public class GroupInvitationResponse {
 
     private String message;
-    private String token;
+    private String groupToken;
 
     @Builder
-    public GroupInvitationResponse(String message, String token) {
+    public GroupInvitationResponse(String message, String groupToken) {
         this.message = message;
-        this.token = token;
+        this.groupToken = groupToken;
     }
 
 }

--- a/backend/photoMap/src/main/java/com/codeZero/photoMap/service/group/GroupInvitationService.java
+++ b/backend/photoMap/src/main/java/com/codeZero/photoMap/service/group/GroupInvitationService.java
@@ -25,12 +25,12 @@ public class GroupInvitationService {
 
     /**
      * 초대 수락(그룹에 멤버 추가)
-     * @param token 초대 토큰
+     * @param groupToken 초대 토큰
      * @param memberId  로그인한 멤버Id
      */
     @Transactional
-    public void acceptInvitation(String token, Long memberId) {
-        GroupInvitation invitation = groupInvitationRepository.findByTokenAndIsDeletedFalse(token)
+    public Long acceptInvitation(String groupToken, Long memberId) {
+        GroupInvitation invitation = groupInvitationRepository.findByGroupTokenAndIsDeletedFalse(groupToken)
                 .orElseThrow(() -> new NotFoundException("유효하지 않거나 만료된 초대 토큰입니다."));
 
         if (invitation.isUsed()) {
@@ -74,6 +74,8 @@ public class GroupInvitationService {
                 .build();
         memberGroupMappingRepository.save(mapping);
 
+        //그룹Id 반환
+        return group.getId();
     }
 
 }


### PR DESCRIPTION
- GroupInvitation의 token 필드명을 groupToken으로 변경
- 초대 링크 URL에 groupToken과 그룹 이름을 인코딩하여 전달하도록 수정
- 초대 수락 API가 로그인 시 groupToken을 request body로 받아 처리 후 group정보 반환